### PR TITLE
🐛 fix(docker): Update Node.js version in Dockerfile for base and production stages

### DIFF
--- a/server/app-authorization/Dockerfile
+++ b/server/app-authorization/Dockerfile
@@ -1,6 +1,6 @@
 #################### BASE STAGE ####################
 # Base image
-FROM node:20-alpine as base
+FROM node:20.13.1-alpine AS base
 
 # Create app directory
 WORKDIR /app
@@ -38,7 +38,7 @@ RUN npm run build
 #################### PRODUCTION STAGE ####################
 
 # Base image
-FROM --platform=linux/amd64 node:latest as production
+FROM --platform=linux/amd64 node:20.13.1-alpine AS production
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the `Dockerfile` in the `server/app-authorization` directory to ensure consistency in the Node.js version used across different stages. The changes standardize the Node.js version to `20.13.1-alpine`.

### Dockerfile updates:

* Updated the base image in the base stage from `node:20-alpine` to `node:20.13.1-alpine` for more precise version control. (`server/app-authorization/Dockerfile`, [server/app-authorization/DockerfileL3-R3](diffhunk://#diff-ae44fcd585d421fb6f33de8784778a50baccfcbeeba9e0f6a9ad3cd31a116e05L3-R3))
* Updated the base image in the production stage from `node:latest` to `node:20.13.1-alpine` to align with the base stage and avoid potential compatibility issues. (`server/app-authorization/Dockerfile`, [server/app-authorization/DockerfileL41-R41](diffhunk://#diff-ae44fcd585d421fb6f33de8784778a50baccfcbeeba9e0f6a9ad3cd31a116e05L41-R41))